### PR TITLE
Cookie not sent for auto login

### DIFF
--- a/src/yii/eauth/EAuth.php
+++ b/src/yii/eauth/EAuth.php
@@ -264,7 +264,10 @@ class EAuth extends Object {
 			'redirect' => $jsRedirect,
 			'params' => $params
 		));
+		ob_start();
 		$widget->run();
+		$output = ob_get_clean();
+		Yii::$app->getResponse()->content = $output;
 		Yii::$app->getResponse()->send();
 	}
 


### PR DESCRIPTION
Cookies not send because  redirectwidget body sended to output with `echo`
