### PR TITLE
Fixed typo in ServiceProxy

### DIFF
--- a/src/nodge/eauth/oauth2/ServiceProxy.php
+++ b/src/nodge/eauth/oauth2/ServiceProxy.php
@@ -55,7 +55,7 @@ class ServiceProxy extends AbstractService {
 	{
 		$this->service = $service;
 		$this->state = $stateStorage;
-		parent::__construct($credentials, $httpClient, $storage, $scopes = array(), $baseApiUri = null);
+		parent::__construct($credentials, $httpClient, $storage, $scopes, $baseApiUri);
 	}
 
 	/**


### PR DESCRIPTION
I believe this is a typo, parameters should be passed to the parent class.
