### PR TITLE
Fix bug for php 7

### DIFF
--- a/src/EAuth.php
+++ b/src/EAuth.php
@@ -10,7 +10,7 @@
 namespace nodge\eauth;
 
 use Yii;
-use yii\base\Object;
+use yii\base\BaseObject;
 use yii\helpers\ArrayHelper;
 use yii\helpers\Url;
 
@@ -19,7 +19,7 @@ use yii\helpers\Url;
  *
  * @package application.extensions.eauth
  */
-class EAuth extends Object
+class EAuth extends BaseObject
 {
 
 	/**

--- a/src/ServiceBase.php
+++ b/src/ServiceBase.php
@@ -10,7 +10,7 @@
 namespace nodge\eauth;
 
 use Yii;
-use yii\base\Object;
+use yii\base\BaseObject;
 use yii\helpers\Url;
 use yii\helpers\ArrayHelper;
 use OAuth\Common\Http\Uri\Uri;
@@ -21,7 +21,7 @@ use OAuth\Common\Http\Client\ClientInterface;
  *
  * @package application.extensions.eauth
  */
-abstract class ServiceBase extends Object implements IAuthService
+abstract class ServiceBase extends BaseObject implements IAuthService
 {
 
 	/**

--- a/src/oauth/HttpClient.php
+++ b/src/oauth/HttpClient.php
@@ -188,7 +188,7 @@ class HttpClient extends AbstractClient
 		curl_setopt($ch, CURLOPT_TIMEOUT, $this->timeout);
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 		curl_setopt($ch, CURLOPT_HEADER, false);
-		curl_setopt($ch, CURLOPT_HTTPHEADER, $this->extraHeaders);
+		curl_setopt($ch, CURLOPT_HTTPHEADER, array_values($this->extraHeaders));
 
 		if ($this->forceSSL3) {
 			curl_setopt($ch, CURLOPT_SSLVERSION, 3);

--- a/src/oauth2/Service.php
+++ b/src/oauth2/Service.php
@@ -182,7 +182,7 @@ abstract class Service extends ServiceBase implements IAuthService
 			array_unshift($route, '');
 
 			// Can not use these params in OAuth2 callbacks
-			foreach (['code', 'state', 'redirect_uri'] as $param) {
+			foreach (['code', 'state', 'redirect_uri', 'scope'] as $param) {
 				if (isset($route[$param])) {
 					unset($route[$param]);
 				}


### PR DESCRIPTION
In some cases, the headers can not go. 

http://php.net/manual/en/function.curl-setopt.php
CURLOPT_HTTPHEADER  An array of HTTP header fields to set, in the format array('Content-type: text/plain', 'Content-length: 100')
