### PR TITLE
Fix facebook oauth bug

### DIFF
--- a/src/services/FacebookOAuth2Service.php
+++ b/src/services/FacebookOAuth2Service.php
@@ -61,17 +61,7 @@ class FacebookOAuth2Service extends Service
 
 		return true;
 	}
-
-	/**
-	 * @return array
-	 */
-	public function getAccessTokenArgumentNames()
-	{
-		$names = parent::getAccessTokenArgumentNames();
-		$names['expires_in'] = 'expires';
-		return $names;
-	}
-
+	
 	/**
 	 * @param string $response
 	 * @return array


### PR DESCRIPTION
Now facebook returns proper expires_in name.
This method provided bug and should be removed