### PR TITLE
remove scope from params for google service

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
 		"php": ">=5.4.0",
 		"lib-curl": "*",
 		"yiisoft/yii2": "*",
-		"carlos-mg89/oauth": "*",
+		"lusitanian/oauth": "~0.3.0",
 		"nodge/lightopenid": "~1.1.0"
 	},
 	"extra": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
 		"php": ">=5.4.0",
 		"lib-curl": "*",
 		"yiisoft/yii2": "*",
-		"lusitanian/oauth": "~0.3.0",
+		"carlos-mg89/oauth": "*",
 		"nodge/lightopenid": "~1.1.0"
 	},
 	"extra": {

--- a/src/EAuth.php
+++ b/src/EAuth.php
@@ -10,7 +10,7 @@
 namespace nodge\eauth;
 
 use Yii;
-use yii\base\Object;
+use yii\base\BaseObject;
 use yii\helpers\ArrayHelper;
 use yii\helpers\Url;
 
@@ -19,7 +19,7 @@ use yii\helpers\Url;
  *
  * @package application.extensions.eauth
  */
-class EAuth extends Object
+class EAuth extends BaseObject
 {
 
 	/**

--- a/src/ServiceBase.php
+++ b/src/ServiceBase.php
@@ -10,7 +10,7 @@
 namespace nodge\eauth;
 
 use Yii;
-use yii\base\Object;
+use yii\base\BaseObject;
 use yii\helpers\Url;
 use yii\helpers\ArrayHelper;
 use OAuth\Common\Http\Uri\Uri;
@@ -21,7 +21,7 @@ use OAuth\Common\Http\Client\ClientInterface;
  *
  * @package application.extensions.eauth
  */
-abstract class ServiceBase extends Object implements IAuthService
+abstract class ServiceBase extends BaseObject implements IAuthService
 {
 
 	/**

--- a/src/oauth/HttpClient.php
+++ b/src/oauth/HttpClient.php
@@ -154,7 +154,7 @@ class HttpClient extends AbstractClient
 		}
 
 		if (is_array($this->requestBody)) {
-			$this->requestBody = http_build_query($this->requestBody, null, '&');
+			$this->requestBody = http_build_query($this->requestBody, "", '&');
 		}
 	}
 

--- a/src/services/GoogleOAuth2Service.php
+++ b/src/services/GoogleOAuth2Service.php
@@ -189,7 +189,7 @@ class GoogleOAuth2Service extends Service
             array_unshift($route, '');
 
             // Can not use these params in OAuth2 callbacks
-            foreach (['code', 'state', 'redirect_uri', 'scope'] as $param) {
+            foreach (['code', 'state', 'redirect_uri', 'scope', 'authuser', 'prompt', 'session_state'] as $param) {
                 if (isset($route[$param])) {
                     unset($route[$param]);
                 }

--- a/src/services/GoogleOAuth2Service.php
+++ b/src/services/GoogleOAuth2Service.php
@@ -12,6 +12,8 @@
 namespace nodge\eauth\services;
 
 use nodge\eauth\oauth2\Service;
+use Yii;
+use yii\helpers\Url;
 
 /**
  * Google provider class.
@@ -166,4 +168,32 @@ class GoogleOAuth2Service extends Service
 			return null;
 		}
 	}
+
+    /**
+     * override getCallbackUrl()
+     * basically its just ignoring 'scope' param for Google, as they return full urls now
+     *
+     * @return string
+     */
+    protected function getCallbackUrl()
+    {
+        if (isset($_GET['redirect_uri'])) {
+            $url = $_GET['redirect_uri'];
+        }
+        else {
+            $route = Yii::$app->getRequest()->getQueryParams();
+            array_unshift($route, '');
+
+            // Can not use these params in OAuth2 callbacks
+            foreach (['code', 'state', 'redirect_uri', 'scope'] as $param) {
+                if (isset($route[$param])) {
+                    unset($route[$param]);
+                }
+            }
+
+            $url = Url::to($route, true);
+        }
+
+        return $url;
+    }
 }

--- a/src/services/GoogleOAuth2Service.php
+++ b/src/services/GoogleOAuth2Service.php
@@ -185,15 +185,9 @@ class GoogleOAuth2Service extends Service
             $url = $_GET['redirect_uri'];
         }
         else {
-            $route = Yii::$app->getRequest()->getQueryParams();
+            $route = array();
             array_unshift($route, '');
-
-            // Can not use these params in OAuth2 callbacks
-            foreach (['code', 'state', 'redirect_uri', 'scope', 'authuser', 'prompt', 'session_state'] as $param) {
-                if (isset($route[$param])) {
-                    unset($route[$param]);
-                }
-            }
+            $route['service'] = $_GET['service'];
 
             $url = Url::to($route, true);
         }

--- a/src/services/GoogleOAuth2Service.php
+++ b/src/services/GoogleOAuth2Service.php
@@ -123,6 +123,10 @@ class GoogleOAuth2Service extends Service
 			$this->attributes['url'] = $info['link'];
 		}
 
+        if (!empty($info['email'])) {
+            $this->attributes['email'] = $info['email'];
+        }
+
 		/*if (!empty($info['gender']))
 			$this->attributes['gender'] = $info['gender'] == 'male' ? 'M' : 'F';
 		


### PR DESCRIPTION
This is more or less the same as Pull request #119 but implements a callback url override just for the GoogleService and not globally as other services might break.

Also it doesn't change your composer.json